### PR TITLE
Checking availability of authorization server

### DIFF
--- a/src/core/request.cpp
+++ b/src/core/request.cpp
@@ -189,11 +189,11 @@ const QString HTTPAuthBearer::header()
     options.AddNameValue("CUSTOMREQUEST", "POST");
     options.AddNameValue("POSTFIELDS", payload);
 
-//    RemoveAuthHeaderCallback();
+    RemoveAuthHeaderCallback();
 
     CPLHTTPResult *result = CPLHTTPFetch(m_tokenServer.toStdString().c_str(), options);
 
-//    InstallAuthHeaderCallback();
+    InstallAuthHeaderCallback();
 
     if(result->nStatus != 0 || result->pszErrBuf != nullptr) {
         if(EQUALN("HTTP error code :", result->pszErrBuf, 17) == FALSE) { // If server error refresh token - logout
@@ -245,7 +245,7 @@ NGRequest::NGRequest() :
     m_retryDelay("5"),
     m_detailedError("")
 {
-//    InstallAuthHeaderCallback();
+    InstallAuthHeaderCallback();
 
 #ifdef Q_OS_WIN
     // Add SSL cert path
@@ -257,7 +257,7 @@ NGRequest::NGRequest() :
 
 NGRequest::~NGRequest()
 {
-//    RemoveAuthHeaderCallback();
+    RemoveAuthHeaderCallback();
 }
 
 void NGRequest::setErrorMessage(const QString &err)
@@ -642,12 +642,8 @@ bool NGRequest::checkURL(const QString &url)
     options.SetNameValue("RETRY_DELAY", "0");
 
     CPLHTTPResult *result = CPLHTTPFetch(url.toStdString().c_str(), options);
-
-    if(result->nStatus != 0  || result->pszErrBuf != nullptr) {
-        CPLHTTPDestroyResult( result );
-        return false;
-    }
+    auto isSuccess = result->nStatus == 0 && result->pszErrBuf == nullptr;
 
     CPLHTTPDestroyResult(result);
-    return true;
+    return isSuccess;
 }

--- a/src/core/request.cpp
+++ b/src/core/request.cpp
@@ -619,3 +619,29 @@ void NGRequest::setProxy(bool useProxy, bool useSystemProxy, const QString &prox
         CPLSetConfigOption("GDAL_PROXY_AUTH", nullptr);
     }
 }
+
+bool NGRequest::checkURL(const QString &url)
+{
+//    MUTEX_LOCKER;
+
+    CPLStringList options(NGRequest::instance().baseOptions());
+
+    options.SetNameValue("CUSTOMREQUEST", "HEAD");
+    options.SetNameValue("NO_BODY", "true");
+    options.SetNameValue("HEADERS", "Accept: */*");
+
+    options.SetNameValue("CONNECTTIMEOUT", "3");
+    options.SetNameValue("TIMEOUT", "5");
+    options.SetNameValue("MAX_RETRY", "0");
+    options.SetNameValue("RETRY_DELAY", "0");
+
+    CPLHTTPResult *result = CPLHTTPFetch(url.toStdString().c_str(), options);
+
+    if(result->nStatus != 0  || result->pszErrBuf != nullptr) {
+        CPLHTTPDestroyResult( result );
+        return false;
+    }
+
+    CPLHTTPDestroyResult(result);
+    return true;
+}

--- a/src/core/request.cpp
+++ b/src/core/request.cpp
@@ -56,8 +56,13 @@
 
 static CPLStringList getOptions(const QString &url) {
     CPLStringList options(NGRequest::instance().baseOptions());
-    QString headers = "Accept: */*";
-    options.AddNameValue("HEADERS", headers.toStdString().c_str());
+    QStringList headers;
+
+    headers.append("Accept: */*");
+    if (!NGRequest::getAuthHeader(url).isNull())
+        headers.append(NGRequest::getAuthHeader(url));
+
+    options.AddNameValue("HEADERS", headers.join("\r\n").toStdString().c_str());
     return options;
 }
 
@@ -69,6 +74,7 @@ static auto gAuthHeaderCallback = [](const char *pszURL) -> std::string
 {
     if (!pszURL)
         return "";
+
     return NGRequest::instance().authHeader(QString(pszURL)).toStdString();
 };
 
@@ -183,11 +189,11 @@ const QString HTTPAuthBearer::header()
     options.AddNameValue("CUSTOMREQUEST", "POST");
     options.AddNameValue("POSTFIELDS", payload);
 
-    RemoveAuthHeaderCallback();
+//    RemoveAuthHeaderCallback();
 
     CPLHTTPResult *result = CPLHTTPFetch(m_tokenServer.toStdString().c_str(), options);
 
-    InstallAuthHeaderCallback();
+//    InstallAuthHeaderCallback();
 
     if(result->nStatus != 0 || result->pszErrBuf != nullptr) {
         if(EQUALN("HTTP error code :", result->pszErrBuf, 17) == FALSE) { // If server error refresh token - logout
@@ -239,7 +245,7 @@ NGRequest::NGRequest() :
     m_retryDelay("5"),
     m_detailedError("")
 {
-    InstallAuthHeaderCallback();
+//    InstallAuthHeaderCallback();
 
 #ifdef Q_OS_WIN
     // Add SSL cert path
@@ -251,7 +257,7 @@ NGRequest::NGRequest() :
 
 NGRequest::~NGRequest()
 {
-    RemoveAuthHeaderCallback();
+//    RemoveAuthHeaderCallback();
 }
 
 void NGRequest::setErrorMessage(const QString &err)
@@ -630,8 +636,8 @@ bool NGRequest::checkURL(const QString &url)
     options.SetNameValue("NO_BODY", "true");
     options.SetNameValue("HEADERS", "Accept: */*");
 
-    options.SetNameValue("CONNECTTIMEOUT", "3");
-    options.SetNameValue("TIMEOUT", "5");
+//    options.SetNameValue("CONNECTTIMEOUT", "3");
+//    options.SetNameValue("TIMEOUT", "5");
     options.SetNameValue("MAX_RETRY", "0");
     options.SetNameValue("RETRY_DELAY", "0");
 

--- a/src/core/request.h
+++ b/src/core/request.h
@@ -57,6 +57,7 @@ public:
                          int proxyPort = 0, const QString &proxyUser = "",
                          const QString &proxyPassword = "",
                          const QString &proxyAuth = "ANY");
+    static bool checkURL(const QString &url);
     static NGRequest &instance();
 
 public:

--- a/src/framework/access/access.cpp
+++ b/src/framework/access/access.cpp
@@ -438,26 +438,28 @@ bool NGAccess::checkEndpoint(const QString &endpoint)
     QString testEndpoint = (endpoint.isNull() ? m_endpoint : endpoint);
 
     if (authType() == AuthSourceType::NGID)
-      testEndpoint = QString("%1/api/v1/settings/ping/").arg(testEndpoint);
+        testEndpoint = QString("%1/api/v1/settings/ping/").arg(testEndpoint);
     else if (authType() == AuthSourceType::KeyCloakOpenID)
-      testEndpoint = QString("%1/auth/realms/master/.well-known/openid-configuration").arg(testEndpoint);
+        testEndpoint = QString("%1/auth/realms/master/.well-known/openid-configuration").arg(testEndpoint);
+    else
+        return true;
 
     return NGRequest::checkURL(testEndpoint);
 }
 
 void NGAccess::checkEndpointAsync(const QString &endpoint)
 {
-  QFuture<bool> future = QtConcurrent::run(this, &NGAccess::checkEndpoint, endpoint);
-  m_updateCheckEndpointWatcher->setFuture(future);
+    QFuture<bool> future = QtConcurrent::run(this, &NGAccess::checkEndpoint, endpoint);
+    m_updateCheckEndpointWatcher->setFuture(future);
 }
 
 void NGAccess::onUpdateCheckEndpoint()
 {
-  if (auto watcher = dynamic_cast<QFutureWatcher<bool>*>(sender()))
-    m_endpointAvailable = watcher->future().result();
+    if (auto watcher = dynamic_cast<QFutureWatcher<bool>*>(sender()))
+        m_endpointAvailable = watcher->future().result();
 
-  emit endpointAvailableUpdated();
-  emit userInfoUpdated();
+    emit endpointAvailableUpdated();
+    emit userInfoUpdated();
 }
 
 bool NGAccess::isFunctionAvailable(const QString &/*app*/, const QString &/*func*/) const
@@ -484,7 +486,7 @@ bool NGAccess::isEnterprise() const
 
 bool NGAccess::isEndpointAvailable() const
 {
-  return m_endpointAvailable;
+    return m_endpointAvailable;
 }
 
 QString NGAccess::getPluginSign(const QString &pluginName, const QString &pluginVersion) const

--- a/src/framework/access/access.h
+++ b/src/framework/access/access.h
@@ -27,6 +27,7 @@
 #include <QFutureWatcher>
 #include <QIcon>
 #include <QObject>
+#include <QTimer>
 
 
 class NGFRAMEWORK_EXPORT NGAccess : public QObject
@@ -45,6 +46,8 @@ public:
     bool isUserSupported() const;
     bool isUserAuthorized() const;
     bool isEnterprise() const;
+    bool isEndpointAvailable() const;
+
     QString getPluginSign(const QString &app, const QString &plugin) const;
 
     void setScope(const QString &scope);
@@ -54,6 +57,7 @@ public:
     void setTokenEndpoint(const QString &endpoint);
     void setUserInfoEndpoint(const QString &endpoint);
     void setUseCodeChallenge(bool val);
+    void setCheckEndpointTimeout(int);
     QString endPoint() const;
     QString authEndpoint() const;
     QString tokenEndpoint() const;
@@ -72,9 +76,13 @@ public:
     QString email() const;
     QStringList userRoles() const;
 
+public slots:
+    void checkEndpoint(const QString &endpoint = QString());
+
 signals:
     void userInfoUpdated();
     void supportInfoUpdated();
+    void endpointAvailableUpdated();
 
 private slots:
     void onUserInfoUpdated();
@@ -99,7 +107,10 @@ protected:
 private:
     bool m_authorized;
     bool m_supported;
+    bool m_endpointAvailable;
+    QTimer m_checkTimer;
     QString m_clientId, m_scope, m_endpoint, m_authEndpoint, m_logoutEndpoint, m_tokenEndpoint, m_userInfoEndpoint;
+    QString m_testEndpoint;
     AuthSourceType m_authType;
     QIcon m_avatar;
     QString m_configDir;

--- a/src/framework/access/access.h
+++ b/src/framework/access/access.h
@@ -73,6 +73,7 @@ public:
     QString tokenEndpoint() const;
     QString userInfoEndpoint() const;
     bool useCodeChallenge() const;
+    bool checkEndpoint(const QString &endpoint = QString());
     enum AuthSourceType authType() const;
 
     void initSentry(bool enabled, const QString &sentryKey, const QString &version = "");
@@ -88,7 +89,8 @@ public:
     QObject* getSignInEventFilter();
 
 public slots:
-    void checkEndpoint(const QString &endpoint = QString());
+    void checkEndpointAsync(const QString &endpoint = QString());
+    void onUpdateCheckEndpoint();
 
 signals:
     void userInfoUpdated();
@@ -126,6 +128,7 @@ private:
     QIcon m_avatar;
     QString m_configDir;
     QFutureWatcher<void> *m_updateUserInfoWatcher, *m_updateSupportInfoWatcher;
+    QFutureWatcher<bool> *m_updateCheckEndpointWatcher;
     QString m_firstName, m_lastName, m_userId, m_email;
     mutable QString m_updateToken;
     QString m_licenseDir;

--- a/src/framework/access/access.h
+++ b/src/framework/access/access.h
@@ -29,6 +29,16 @@
 #include <QObject>
 #include <QTimer>
 
+class SignInEvent : public QObject
+{
+    Q_OBJECT
+
+public:
+    SignInEvent(QObject *parent = nullptr);
+
+protected:
+    bool eventFilter(QObject *obj, QEvent *event) override;
+};
 
 class NGFRAMEWORK_EXPORT NGAccess : public QObject
 {
@@ -75,6 +85,7 @@ public:
     QString userId() const;
     QString email() const;
     QStringList userRoles() const;
+    QObject* getSignInEventFilter();
 
 public slots:
     void checkEndpoint(const QString &endpoint = QString());
@@ -110,7 +121,7 @@ private:
     bool m_endpointAvailable;
     QTimer m_checkTimer;
     QString m_clientId, m_scope, m_endpoint, m_authEndpoint, m_logoutEndpoint, m_tokenEndpoint, m_userInfoEndpoint;
-    QString m_testEndpoint;
+    SignInEvent *m_signInEvent;
     AuthSourceType m_authType;
     QIcon m_avatar;
     QString m_configDir;

--- a/src/framework/access/signbutton.cpp
+++ b/src/framework/access/signbutton.cpp
@@ -25,6 +25,8 @@
 #include <QPainter>
 #include <QPushButton>
 
+constexpr int CHECK_ENDPOINT_AVAILABILITY_DELAY_MS = 500;
+
 // NOTE: If AuthSourceType is custom, before create NGSignInButton must execute
 //       NGAccess::instance().setAuthEndpoint, NGAccess::instance().setTokenEndpoint and
 //       NGAccess::instance().setUserInfoEndpoint
@@ -39,7 +41,7 @@ NGSignInButton::NGSignInButton(const QString &clientId,
     NGAccess::instance().setScope(scope);
     NGAccess::instance().setClientId(clientId);
 
-    QTimer::singleShot(500, [] () {
+    QTimer::singleShot(CHECK_ENDPOINT_AVAILABILITY_DELAY_MS, [] () {
         NGAccess::instance().checkEndpointAsync();
     });
     onUserInfoUpdated();

--- a/src/framework/access/signbutton.cpp
+++ b/src/framework/access/signbutton.cpp
@@ -22,6 +22,8 @@
 #include "signdialog.h"
 
 #include <QIcon>
+#include <QPainter>
+#include <QPushButton>
 
 // NOTE: If AuthSourceType is custom, before create NGSignInButton must execute
 //       NGAccess::instance().setAuthEndpoint, NGAccess::instance().setTokenEndpoint and
@@ -37,12 +39,7 @@ NGSignInButton::NGSignInButton(const QString &clientId,
     NGAccess::instance().setScope(scope);
     NGAccess::instance().setClientId(clientId);
 
-    if(NGAccess::instance().isUserAuthorized()) {
-        setIcon(NGAccess::instance().avatar());
-    }
-    else {
-        setIcon(QIcon(":/icons/person-blue.svg"));
-    }
+    onUserInfoUpdated();
 
     connect(this, SIGNAL(clicked()), this, SLOT(onClick()));
     connect(&NGAccess::instance(), SIGNAL(userInfoUpdated()), this, SLOT(onUserInfoUpdated()));
@@ -70,11 +67,20 @@ void NGSignInButton::onClick()
 
 void NGSignInButton::onUserInfoUpdated()
 {
-    if(NGAccess::instance().isUserAuthorized()) {
-        setIcon(NGAccess::instance().avatar());
+    QIcon userIcon = (NGAccess::instance().isUserAuthorized() ?
+                          NGAccess::instance().avatar() :
+                          QIcon(":/icons/person-blue.svg") );
+
+    if (!NGAccess::instance().isEndpointAvailable()) {
+        QPixmap pixmap = userIcon.pixmap(userIcon.actualSize(QSize(64, 64)));
+        QPainter painter(&pixmap);
+        painter.setPen(Qt::red);
+        painter.setBrush(Qt::red);
+        painter.drawEllipse(0, 0, 32, 32);
+        userIcon = QIcon(pixmap);
     }
-    else {
-        setIcon(QIcon(":/icons/person-blue.svg"));
-    }
+
+    setIcon(userIcon);
+
     emit userInfoUpdated();
 }

--- a/src/framework/access/signbutton.cpp
+++ b/src/framework/access/signbutton.cpp
@@ -39,6 +39,9 @@ NGSignInButton::NGSignInButton(const QString &clientId,
     NGAccess::instance().setScope(scope);
     NGAccess::instance().setClientId(clientId);
 
+    QTimer::singleShot(500, [] () {
+        NGAccess::instance().checkEndpoint();
+    });
     onUserInfoUpdated();
 
     connect(this, SIGNAL(clicked()), this, SLOT(onClick()));

--- a/src/framework/access/signbutton.cpp
+++ b/src/framework/access/signbutton.cpp
@@ -40,7 +40,7 @@ NGSignInButton::NGSignInButton(const QString &clientId,
     NGAccess::instance().setClientId(clientId);
 
     QTimer::singleShot(500, [] () {
-        NGAccess::instance().checkEndpoint();
+        NGAccess::instance().checkEndpointAsync();
     });
     onUserInfoUpdated();
 

--- a/src/framework/access/signdialog.cpp
+++ b/src/framework/access/signdialog.cpp
@@ -27,6 +27,7 @@ NGSignDialog::NGSignDialog(QWidget *parent) :
     ui(new Ui::NGSignDialog)
 {
     ui->setupUi(this);
+    ui->signButton->installEventFilter(NGAccess::instance().getSignInEventFilter());
     updateContent();
 }
 

--- a/src/framework/access/signdialog.cpp
+++ b/src/framework/access/signdialog.cpp
@@ -85,6 +85,8 @@ void NGSignDialog::updateContent()
         ui->ngLogo->show();
         ui->descriptionText->show();
     }
+
+    ui->signButton->setEnabled(NGAccess::instance().isUserAuthorized() || NGAccess::instance().isEndpointAvailable());
 }
 
 QPushButton *NGSignDialog::getSignButton () const

--- a/src/framework/access/signdialog.cpp
+++ b/src/framework/access/signdialog.cpp
@@ -87,7 +87,10 @@ void NGSignDialog::updateContent()
         ui->descriptionText->show();
     }
 
-    ui->signButton->setEnabled(NGAccess::instance().isUserAuthorized() || NGAccess::instance().isEndpointAvailable());
+    const bool isUserAuthorized = NGAccess::instance().isUserAuthorized();
+    const bool isEndpointAvailable = NGAccess::instance().isEndpointAvailable();
+
+    ui->signButton->setEnabled(isUserAuthorized || (!isUserAuthorized && isEndpointAvailable));
 }
 
 QPushButton *NGSignDialog::getSignButton () const


### PR DESCRIPTION
Зависит от изменений nextqisqgis!
[nextqisqgis pull request](https://github.com/nextgis/nextgisqgis/pull/95/)
Отключены callback авторизационных заголовков, со старым ngisqgis не авторизуется.

- [Проверять доступность NGID перед авторизацией](https://app.clickup.com/t/85ztntf9g)
- [Использовать одну библиотеку для работы с сетью](https://app.clickup.com/t/85ztntfx0)
- [В ngstd добавить проверку доступности сервера авторизации](https://app.clickup.com/t/85ztntqjp)

PS: Может зря отключил:
- https://github.com/nextgis/lib_ngstd/blob/master/src/core/request.cpp#L242
- https://github.com/nextgis/lib_ngstd/blob/master/src/core/request.cpp#L254 
но убрать их предлагалось в описании задачи.
Вообще они при текущей реализации никак не задействуются при включении перехватчика через QNetwork, для обратной совместимости библиотеки я бы их оставил включенными.

Основной вопрос по функциям [CPLHTTPSetFetchCallback] сейчас используется (https://github.com/OSGeo/gdal/blob/a7ee4d8eecabd08421c5d662836391839c869342/port/cpl_http.cpp#L860).
По идее он вообще никак не конфликтует с остальными провайдерами в соответствии с описанием, глобальных больш в программе нет.

`/** Installs an alternate callback to the default implementation of
 * CPLHTTPFetchEx().
 *
 * This callback will be used by all threads, unless contextual callbacks are
 * installed with CPLHTTPPushFetchCallback().`
 
А при текущей реализации QGIS QgsCPLHTTPFetchOverrider применяется локально в области видимости функций, каждый раз отдельно. Это его так надо размещать не в qgis а в lib_ngstd, что вызвало еще больше вопросов, тк CPLHTTPPushFetchCallback не многопоточный, а вешать интерфейс задержками проверок тоже плохо.